### PR TITLE
Add --domain argument support

### DIFF
--- a/dp_file_uploader/__init__.py
+++ b/dp_file_uploader/__init__.py
@@ -37,11 +37,23 @@ def get_port(args):
     return port
 
 
-def normalize_directory(directory):
-    if directory.endswith('/'):
-        return directory
+def get_domain(args):
+    if args.domain is not None:
+        domain = args.domain[0]
     else:
-        return directory + '/'
+        domain = None
+    return domain
+
+
+def normalize_directory(directory, domain):
+    prefix, suffix = directory.split(":")
+    _, subpath = suffix.split("///")
+    if not subpath.endswith('/'):
+        subpath = subpath + '/'
+    if domain is not None:
+        return prefix + ":///" + domain + "/" + subpath
+    else:
+        return prefix + ":///" + subpath
 
 
 def build_url(hostname, port):
@@ -121,6 +133,7 @@ def run_with_args(args):
     url = build_url(hostname, port)
     user = get_user(args)
     password = get_password(args)
-    directory = normalize_directory(args.directory[0])
+    domain = get_domain(args)
+    directory = normalize_directory(args.directory[0], domain)
     for filename in args.fileName:
         process_file(filename, directory, url, user, password)

--- a/dp_file_uploader/command_line.py
+++ b/dp_file_uploader/command_line.py
@@ -21,6 +21,7 @@ def process_args():
     argparser.add_argument('-P', '--port', type=int, nargs=1, help='xml-mgmt port, default: 5550')
     argparser.add_argument('-u', '--user', type=str, nargs=1, help='username, default: admin')
     argparser.add_argument('-p', '--password', type=str, nargs=1, help='password, default: admin')
+    argparser.add_argument('-d', '--domain', type=str, nargs=1, help='application domain')
     argparser.add_argument('-V', '--verbose', action='store_true', help='verbose output')
     argparser.add_argument('-v', '--version', action='version', version=get_version())
     argparser.add_argument('fileName', type=str, nargs='+', help='file(s) to push')


### PR DESCRIPTION
Example usage:

```
$ dp-file-uploader my.datapower.com --domain app "local:///subdir"  file.txt
```

The above is equivalent to:

```
$ dp-file-uploader my.datapower.com "local:///app/subdir"  file.txt
```

Closes: #8 